### PR TITLE
fix: poll only works for array not plain object

### DIFF
--- a/docs/triggers/poll.md
+++ b/docs/triggers/poll.md
@@ -36,7 +36,7 @@ on:
 
 - `url`, required, `string` or `string[]`, the polling API URL, for example, `https://jsonplaceholder.typicode.com/posts`, if using multiple urls the response structure should be same.
 
-- `itemsPath`, optional, if the API's returned JSON is not a list and is instead an object (maybe paginated), you should configure `itemsPath` as the key that contains the results. Example: `results`, `items`, `data.items`, etc... The default value is `undefined`, which means the API's response should be a list.
+- `itemsPath`, optional, if the API's returned JSON is not a list and is instead an object (maybe paginated), you can configure `itemsPath` as the key that contains the results. Example: `results`, `items`, `data.items`, etc... The default value is `undefined`, which means the API's response should be a list. If `itemsPath` is not specified and the API's response is an object, the object will be converted to an `items` array.
 
 - `deduplicationKey`, optional. The poll trigger deduplicates the array we see each poll against the id key. If the id key does not exist, you should specify an alternative unique key to deduplicate, you can use path format, like: `id`, `data.id`, `item.data.key`, If neither are supplied, we fallback to looking for `key`, if neither are supplied, we will hash the item, and generate a unique key
 

--- a/packages/actionsflow/src/triggers/__tests__/poll.test.ts
+++ b/packages/actionsflow/src/triggers/__tests__/poll.test.ts
@@ -195,6 +195,23 @@ test("poll trigger with complex response and deduplicationKey as key", async () 
   const itemKey = poll.getItemKey(triggerResults[0]);
   expect(itemKey).toBe("https://jsonplaceholder.typicode.com/posts__1");
 });
+test("poll trigger with complex response and not as array", async () => {
+  const justObjResp = {
+    data: { userId: 10 },
+  };
+  const axios = jest.fn();
+  axios.mockImplementation(() => Promise.resolve(justObjResp));
+  helpers.axios = (axios as unknown) as AxiosStatic;
+  const constructionParams = await getTriggerConstructorParams({
+    options: { url: "https://jsonplaceholder.typicode.com/posts" },
+    name: "poll",
+  });
+  constructionParams.helpers = helpers;
+  const poll = new Poll(constructionParams);
+  const triggerResults = await poll.run();
+  expect(triggerResults.length).toBe(1); // will only have one since we just convert a single object to an array
+  expect(triggerResults[0].userId).toBe(10);
+});
 test("poll trigger with deduplicationKey no found", async () => {
   const resp2 = {
     data: [

--- a/packages/actionsflow/src/triggers/poll.ts
+++ b/packages/actionsflow/src/triggers/poll.ts
@@ -85,11 +85,11 @@ export default class Poll implements ITriggerClassType {
       }
       // For now we just take the items and ignore everything else
       if (requestResult && requestResult.data) {
-        const itemsArray: AnyObject[] = itemsPath
+        let itemsArray: AnyObject[] = itemsPath
           ? get(requestResult.data, itemsPath)
           : requestResult.data;
         if (!Array.isArray(itemsArray)) {
-          throw new Error("Can not found a valid items result");
+          itemsArray = [itemsArray];
         }
         const deepClonedData = clonedeep(itemsArray);
         itemsArray.forEach((item) => {


### PR DESCRIPTION
<!--
  Have any questions? Check out the contributing docs at https://github.com/actionsflow/actionsflow/blob/main/docs/contributing.md, or
  ask in this Pull Request and a Actionsflow maintainer will be happy to help :)
-->

## Description

Instead of throwing an error when the poll response is an plain object, this PR converts it back to an array to continue working.

### Documentation

Updated the `docs/triggers/poll.md`

<!--
  Where is this feature or API documented?

  - If it's a documentation pull request?
    - If so, you can ignore here.
  - If docs exist:
    - Update any references, if relevant. This includes Guides and Actionsflow Internals docs.
  - If no docs exist:
    - Create a stub for documentation at `docs` including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
