### PR TITLE
Update test-example-daily.yml - inject env var for forcing node12

### DIFF
--- a/.github/workflows/test-example-daily.yml
+++ b/.github/workflows/test-example-daily.yml
@@ -7,6 +7,8 @@ on:
     # * is a special character in YAML so you have to quote this string
     - cron: "20 9 * * *"
   workflow_dispatch:
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
 jobs:
   build:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/

This is a temporary measure to fix the workflow. 

Since it's been forced to run on node16 by default, and errors have occurred; there's probably more to be done.

<!--
  Have any questions? Check out the contributing docs at https://github.com/actionsflow/actionsflow/blob/main/docs/contributing.md, or
  ask in this Pull Request and a Actionsflow maintainer will be happy to help :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

This might relieve the failing jobs running for [test-example-daily](https://github.com/actionsflow/actionsflow/actions/workflows/test-example-daily.yml)

![image](https://github.com/actionsflow/actionsflow/assets/134478/db293ec1-6105-4c20-a50e-2a6916a03a52)


### Documentation

<!--
  Where is this feature or API documented?

  - If it's a documentation pull request?
    - If so, you can ignore here.
  - If docs exist:
    - Update any references, if relevant. This includes Guides and Actionsflow Internals docs.
  - If no docs exist:
    - Create a stub for documentation at `docs` including bullet points for how to use the feature, code snippets (including from happy path tests), etc.
-->

## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->
Apologies for the awkwardness of this PR, I need to test the run to see if this relieves the issues and then the investigation of the changes necessary for running on node16 would have to be done.

I've been happily using actionsflow for weeks without running into any issues with node12 or node16 beinf forced thus far. (I think it's running on node18)

There is an alternative, that I do see has [been done on other workflows](https://github.com/actionsflow/actionsflow/commit/4e6255c6c70ddefe25aa33457de8083cbc6288b1), which is using node14.