### PR TITLE
feat(weather): update openweathermap api to 3.0

### DIFF
--- a/packages/actionsflow-trigger-weather/src/index.ts
+++ b/packages/actionsflow-trigger-weather/src/index.ts
@@ -14,7 +14,7 @@ export default class Weather implements ITriggerClassType {
   helpers: IHelpers;
   api = "onecall";
   apiKey = "";
-  endpoint = "https://api.openweathermap.org/data/2.5/";
+  endpoint = "https://api.openweathermap.org/data/3.0/";
   getItemKey(item: AnyObject): string {
     if (this.endpoint && this.api) {
       return (this.endpoint + this.api + "__" + Date.now()) as string;


### PR DESCRIPTION
## Description

This PR update the openweather api version used by the weather plugin to 3.0 version.

Last days, I've got some 401 issues on my running jobs using the weather plugin.
It seems that the problem comes from the calls to the openweathermap API in version 2.5.

After some tests, I get weather responses again when I'm using the 3.0 API version.

### Documentation

The onecall API documentation used by the weather plugin : https://openweathermap.org/api/one-call-3

